### PR TITLE
fix: 入力フィールドのライトモード時の文字色問題を修正

### DIFF
--- a/spec-ai-writer/frontend/src/index.css
+++ b/spec-ai-writer/frontend/src/index.css
@@ -55,7 +55,9 @@ body {
 
   .input {
     @apply w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
-           focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-gray-700 dark:text-white;
+           bg-white text-gray-900
+           focus:outline-none focus:ring-2 focus:ring-primary-500
+           dark:bg-gray-700 dark:text-white;
   }
 
   .badge {


### PR DESCRIPTION
## Summary

- フロントエンドの入力フィールドで、ライトモード時に文字色と背景色が両方白になり見えない問題を修正
- `.input` クラスにライトモード用の `bg-white text-gray-900` を追加

## Test plan

- [ ] ライトモードで新規プロジェクト作成モーダルを開き、入力フィールドの文字が見えることを確認
- [ ] ライトモードでインタビュー画面のチャット入力欄の文字が見えることを確認
- [ ] ダークモードでも入力フィールドが正しく表示されることを確認

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)