### PR TITLE
Stabilize Interview WebSocket handling and Zustand store usage

### DIFF
--- a/spec-ai-writer/frontend/src/pages/Interview.tsx
+++ b/spec-ai-writer/frontend/src/pages/Interview.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { Send, ArrowLeft, Loader2 } from 'lucide-react';
 import { useInterviewStore } from '@/store/useInterviewStore';
@@ -13,59 +13,19 @@ export default function Interview() {
   const [error, setError] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  const {
-    messages,
-    currentPhase,
-    phaseName,
-    isWaitingForResponse,
-    addMessage,
-    setCurrentPhase,
-    setProjectName,
-    setInterviewActive,
-    setWaitingForResponse,
-  } = useInterviewStore();
+  const messages = useInterviewStore((state) => state.messages);
+  const currentPhase = useInterviewStore((state) => state.currentPhase);
+  const phaseName = useInterviewStore((state) => state.phaseName);
+  const isWaitingForResponse = useInterviewStore(
+    (state) => state.isWaitingForResponse
+  );
+  const setProjectName = useInterviewStore((state) => state.setProjectName);
+  const setInterviewActive = useInterviewStore((state) => state.setInterviewActive);
 
-  useEffect(() => {
-    if (!projectName) return;
-
-    setProjectName(projectName);
-
-    // Initialize WebSocket
-    const websocket = new WebSocketManager(projectName);
-    setWs(websocket);
-
-    websocket
-      .connect()
-      .then(() => {
-        setIsConnecting(false);
-        setInterviewActive(true);
-      })
-      .catch((err) => {
-        console.error('Failed to connect:', err);
-        setError('WebSocket接続に失敗しました');
-        setIsConnecting(false);
-      });
-
-    // Handle incoming messages
-    const unsubscribe = websocket.onMessage((message: WebSocketMessage) => {
-      handleWebSocketMessage(message);
-    });
-
-    // Cleanup
-    return () => {
-      unsubscribe();
-      websocket.disconnect();
-      setInterviewActive(false);
-    };
-  }, [projectName]);
-
-  useEffect(() => {
-    // Auto-scroll to bottom
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
-
-  const handleWebSocketMessage = (message: WebSocketMessage) => {
+  const handleWebSocketMessage = useCallback((message: WebSocketMessage) => {
     console.log('Received message:', message);
+    const { addMessage, setCurrentPhase, setInterviewActive, setWaitingForResponse } =
+      useInterviewStore.getState();
 
     switch (message.type) {
       case 'question':
@@ -120,8 +80,54 @@ export default function Interview() {
         });
         setWaitingForResponse(false);
         break;
+
+      default:
+        addMessage({
+          role: 'system',
+          content: `⚠️ 未対応のメッセージ: ${message.type}`,
+          timestamp: new Date().toISOString(),
+        });
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    if (!projectName) return;
+
+    setProjectName(projectName);
+
+    // Initialize WebSocket
+    const websocket = new WebSocketManager(projectName);
+    setWs(websocket);
+
+    websocket
+      .connect()
+      .then(() => {
+        setIsConnecting(false);
+        setInterviewActive(true);
+      })
+      .catch((err) => {
+        console.error('Failed to connect:', err);
+        setError('WebSocket接続に失敗しました');
+        setIsConnecting(false);
+      });
+
+    // Handle incoming messages
+    const unsubscribe = websocket.onMessage((message: WebSocketMessage) => {
+      handleWebSocketMessage(message);
+    });
+
+    // Cleanup
+    return () => {
+      unsubscribe();
+      websocket.disconnect();
+      setInterviewActive(false);
+    };
+  }, [handleWebSocketMessage, projectName, setInterviewActive, setProjectName]);
+
+  useEffect(() => {
+    // Auto-scroll to bottom
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -135,7 +141,7 @@ export default function Interview() {
       timestamp: new Date().toISOString(),
     };
 
-    addMessage(userMessage);
+    useInterviewStore.getState().addMessage(userMessage);
 
     // Send to WebSocket
     ws.sendAnswer(input.trim());


### PR DESCRIPTION
### Motivation
- Prevent stale closures and ensure WebSocket message handlers use the latest store actions and state.
- Reduce unnecessary re-renders by subscribing only to the specific slices of the interview store.
- Provide clearer handling for unexpected/unknown WebSocket message types.

### Description
- Replace a single destructured `useInterviewStore()` call with selector subscriptions like `useInterviewStore((s) => s.messages)` and `useInterviewStore((s) => s.setProjectName)` to narrow subscriptions.
- Move `handleWebSocketMessage` into a `useCallback` and read actions (`addMessage`, `setCurrentPhase`, `setInterviewActive`, `setWaitingForResponse`) from `useInterviewStore.getState()` to avoid stale references.
- Add a default fallback branch for unknown `message.type` values that logs a system message.
- Update `handleSubmit` to call `useInterviewStore.getState().addMessage(...)` so user messages are added using the latest store action.

### Testing
- No automated tests were executed as part of this change.
- (No test failures reported.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695be763ca588330982e374e1f9e6e81)