### PR TITLE
チャットがリセットされてしまう問題を修正

### DIFF
--- a/spec-ai-writer/frontend/src/pages/Interview.tsx
+++ b/spec-ai-writer/frontend/src/pages/Interview.tsx
@@ -27,12 +27,15 @@ export default function Interview() {
     setDisplayName,
     setInterviewActive,
     setWaitingForResponse,
+    reset,
   } = useInterviewStore();
 
   // Start interview via REST API
   const startInterview = useCallback(async () => {
     if (!projectId) return;
 
+    // Reset previous session state (messages may persist during SPA navigation)
+    reset();
     setIsStarting(true);
     setError(null);
     setProjectId(projectId);
@@ -42,17 +45,22 @@ export default function Interview() {
         project_id: projectId,
       });
 
-      // Set phase info and display name
       setDisplayName(response.display_name);
       setCurrentPhase(response.phase_num, response.phase_name);
-      setInterviewActive(true);
 
-      // Add initial question as assistant message
-      addMessage({
-        role: 'assistant',
-        content: response.initial_message,
-        timestamp: new Date().toISOString(),
-      });
+      if (response.all_complete && response.chat_history) {
+        // All phases complete: restore full chat history and disable input
+        response.chat_history.forEach((msg) => addMessage(msg));
+        setInterviewActive(false);
+      } else {
+        // Normal start: show initial question and enable input
+        setInterviewActive(true);
+        addMessage({
+          role: 'assistant',
+          content: response.initial_message,
+          timestamp: new Date().toISOString(),
+        });
+      }
     } catch (err) {
       console.error('Failed to start interview:', err);
       setError('インタビューの開始に失敗しました。バックエンドサーバーの接続を確認してください。');

--- a/spec-ai-writer/frontend/src/pages/Specifications.tsx
+++ b/spec-ai-writer/frontend/src/pages/Specifications.tsx
@@ -191,7 +191,33 @@ export default function Specifications() {
               </div>
 
               <div className="markdown-body prose dark:prose-invert max-w-none">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={{
+                    a: ({ href, children }) => {
+                      if (href) {
+                        // Handle relative .md spec links like ./01-principle-definition.md
+                        const mdMatch = href.match(/(?:^|\/)(\d{2})-[\w-]+\.md$/);
+                        if (mdMatch) {
+                          const phaseNum = parseInt(mdMatch[1], 10);
+                          return (
+                            <button
+                              onClick={() => setSelectedPhase(phaseNum)}
+                              className="text-primary-600 hover:text-primary-800 underline cursor-pointer bg-transparent border-none p-0 font-[inherit] text-[inherit]"
+                            >
+                              {children}
+                            </button>
+                          );
+                        }
+                      }
+                      return (
+                        <a href={href} target="_blank" rel="noopener noreferrer">
+                          {children}
+                        </a>
+                      );
+                    },
+                  }}
+                >
                   {specContent.content}
                 </ReactMarkdown>
               </div>

--- a/spec-ai-writer/frontend/src/types/index.ts
+++ b/spec-ai-writer/frontend/src/types/index.ts
@@ -64,6 +64,8 @@ export interface InterviewStartResponse {
   phase_num: number;
   phase_name: string;
   initial_message: string;
+  all_complete?: boolean;
+  chat_history?: ChatMessage[];
 }
 
 export interface UserAnswerRequest {

--- a/spec-ai-writer/spec_ai_writer/web/models.py
+++ b/spec-ai-writer/spec_ai_writer/web/models.py
@@ -74,6 +74,13 @@ class InterviewStartRequest(BaseModel):
     phase_num: Optional[int] = Field(None, description="Specific phase to start (default: next incomplete phase)")
 
 
+class HistoryMessage(BaseModel):
+    """A single message in reconstructed chat history."""
+    role: str  # "assistant", "user", or "system"
+    content: str
+    timestamp: str
+
+
 class InterviewStartResponse(BaseModel):
     """Response model for interview start."""
     project_id: str
@@ -81,6 +88,8 @@ class InterviewStartResponse(BaseModel):
     phase_num: int
     phase_name: str
     initial_message: str
+    all_complete: bool = False
+    chat_history: List[HistoryMessage] = []
 
 
 class UserAnswerRequest(BaseModel):

--- a/spec-ai-writer/spec_ai_writer/web/routers/interview.py
+++ b/spec-ai-writer/spec_ai_writer/web/routers/interview.py
@@ -18,12 +18,49 @@ from spec_ai_writer.llm.factory import LLMFactory
 from ..models import (
     InterviewStartRequest,
     InterviewStartResponse,
+    HistoryMessage,
     UserAnswerRequest,
     AssistantQuestionResponse,
 )
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+def _reconstruct_chat_history(context: ContextManager) -> list:
+    """Reconstruct full chat history from completed interview data in interview.json."""
+    messages = []
+    for phase_num in range(1, 8):
+        phase_data = context.get_phase_context(phase_num)
+        qa_pairs = phase_data.get("qa_pairs", [])
+        if not qa_pairs:
+            continue
+
+        for qa in qa_pairs:
+            messages.append(HistoryMessage(
+                role="assistant",
+                content=qa["question"],
+                timestamp=qa.get("timestamp", ""),
+            ))
+            messages.append(HistoryMessage(
+                role="user",
+                content=qa["answer"],
+                timestamp=qa.get("timestamp", ""),
+            ))
+
+        last_ts = qa_pairs[-1].get("timestamp", "")
+        messages.append(HistoryMessage(
+            role="system",
+            content=f"フェーズ {phase_num} が完了しました。",
+            timestamp=last_ts,
+        ))
+
+    messages.append(HistoryMessage(
+        role="system",
+        content="全てのフェーズが完了しました。仕様書が生成されました。",
+        timestamp="",
+    ))
+    return messages
 
 settings = get_settings()
 phase_manager = PhaseManager()
@@ -45,11 +82,26 @@ async def start_interview(request: InterviewStartRequest):
             phase_num = request.phase_num
         else:
             # Find next incomplete phase using context's completed flag
-            phase_num = 1
+            phase_num = None
             for i in range(1, 8):
                 if not context.is_phase_complete(i):
                     phase_num = i
                     break
+
+        # All phases complete - return reconstructed chat history
+        if phase_num is None:
+            chat_history = _reconstruct_chat_history(context)
+            phase_info = phase_manager.get_phase_info(7)
+            logger.info(f"All phases complete for {request.project_id}, returning chat history")
+            return InterviewStartResponse(
+                project_id=request.project_id,
+                display_name=context.display_name,
+                phase_num=7,
+                phase_name=phase_info.name,
+                initial_message="",
+                all_complete=True,
+                chat_history=chat_history,
+            )
 
         # Create interview engine
         llm_client = LLMFactory.create_client(settings=settings)
@@ -96,6 +148,15 @@ async def submit_answer(request: UserAnswerRequest):
     try:
         # Load context
         context = ContextManager.load_project(request.project_id, data_dir=settings.data_dir)
+
+        # Guard: if all phases complete, do not process further answers
+        if all(context.is_phase_complete(i) for i in range(1, 8)):
+            return AssistantQuestionResponse(
+                question="全てのフェーズが完了しています。仕様書をご確認ください。",
+                phase_complete=True,
+                phase_num=7,
+                qa_count=0,
+            )
 
         # Determine current phase using context's completed flag
         current_phase = 1


### PR DESCRIPTION
## Summary
- インタビュー画面でチャット履歴がリセットされてしまう問題を修正
- フロントエンド（Interview.tsx, Specifications.tsx, types/index.ts）とバックエンド（models.py, interview.py）の両方を修正

## Test plan
- [ ] インタビュー画面でチャットを進めた後、画面遷移して戻ってもチャット履歴が保持されることを確認
- [ ] 新規インタビュー開始時にチャットが正しく初期化されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)