### PR TITLE
fix: 再インタビュー・ダウンロードボタンのUXを改善 (Issue #35)

### DIFF
--- a/spec-ai-writer/docs/plans/20260327ux-reinterview-button.md
+++ b/spec-ai-writer/docs/plans/20260327ux-reinterview-button.md
@@ -15,6 +15,10 @@
 - 再インタビュー・ダウンロードボタンのスタイルを `btn-ghost` から `btn-secondary` に変更
 - 再インタビューボタンは `spec.exists === true` のフェーズのみ表示
 
+## 注意事項
+
+`spec.exists` によるボタン非表示はUX改善であり、セキュリティ上の認可制御ではない。`resetPhase` / `downloadSpecification` のアクセス権チェックはバックエンド側で担保すること。
+
 ## 変更ファイル
 
 - `spec-ai-writer/frontend/src/pages/Specifications.tsx` L158-183

--- a/spec-ai-writer/frontend/src/pages/Specifications.tsx
+++ b/spec-ai-writer/frontend/src/pages/Specifications.tsx
@@ -164,6 +164,7 @@ export default function Specifications() {
                       }}
                       className="btn btn-secondary p-1"
                       title="再インタビュー"
+                      aria-label="再インタビュー"
                     >
                       <RotateCcw className="h-4 w-4" />
                     </button>
@@ -175,6 +176,7 @@ export default function Specifications() {
                         handleDownload(spec.phase_num, spec.filename);
                       }}
                       className="btn btn-secondary p-1"
+                      aria-label="ダウンロード"
                     >
                       <Download className="h-4 w-4" />
                     </button>


### PR DESCRIPTION
## Summary

- 再インタビュー・ダウンロードボタンのスタイルを `btn-ghost` から `btn-secondary` に変更し、透明から視認できるスタイルに修正
- 仕様書が存在するフェーズのみ再インタビューボタンを表示するよう制御を追加

Closes #35

## Test plan

- [x] 仕様書が存在するフェーズに再インタビューボタンとダウンロードボタンが表示される
- [x] 仕様書が存在しないフェーズに再インタビューボタンが表示されない
- [x] 両ボタンが `btn-secondary` スタイルで視認しやすく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)